### PR TITLE
Add test for --vault-password-file script

### DIFF
--- a/test/fixture/repo.git/.vault-pass-script
+++ b/test/fixture/repo.git/.vault-pass-script
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "pa55word"

--- a/test/git-diff-ansible-vault.bats
+++ b/test/git-diff-ansible-vault.bats
@@ -139,6 +139,14 @@ EOF
   assert_line "+    - bash"
 }
 
+@test "--vault-password-file with specified script unlocks vault" {
+  run git diff-ansible-vault --vault-password-file .vault-pass-script --verbose
+  assert_success
+  assert_line "[INFO] VAULT_PASSWORD_FILE: .vault-pass-script"
+  assert_line "diff --git a/vault.yml b/vault.yml"
+  assert_line "+    - bash"
+}
+
 @test "--vault-password-file with non-existant path exits with error" {
   run git diff-ansible-vault --vault-password-file .not-a-file
   assert_failure "[ERROR] --vault-password-file not found: .not-a-file"


### PR DESCRIPTION
**Because:**
- Ansible Vault's `--vault-password-file` can accept a script.
  `git-diff-ansible-vault`'s argument should do the same, ref:
  http://docs.ansible.com/ansible/playbooks_vault.html#running-a-playbook-with-vault

**This change:**
- Adds a test.
- This functionality was already implicitly supported.

Fixes #8
