### PR TITLE
Set vault password file via environment variable

### DIFF
--- a/bin/git-diff-ansible-vault
+++ b/bin/git-diff-ansible-vault
@@ -299,6 +299,14 @@ git_diff_ansible_vault() {
 }
 
 #
+# Read environment variables.
+#
+
+if [ -f "$ANSIBLE_VAULT_PASSWORD_FILE" ]; then
+  VAULT_PASSWORD_FILE="$ANSIBLE_VAULT_PASSWORD_FILE"
+fi
+
+#
 # parse argv
 #
 

--- a/test/git-diff-ansible-vault.bats
+++ b/test/git-diff-ansible-vault.bats
@@ -131,6 +131,14 @@ EOF
   assert_failure "[ERROR] Not a git repository"
 }
 
+@test "Setting vault password file via environment variable unlocks vault" {
+  ANSIBLE_VAULT_PASSWORD_FILE=.alternate-vault-pass run git diff-ansible-vault --verbose
+  assert_success
+  assert_line "[INFO] VAULT_PASSWORD_FILE: .alternate-vault-pass"
+  assert_line "diff --git a/vault.yml b/vault.yml"
+  assert_line "+    - bash"
+}
+
 @test "--vault-password-file with specified path unlocks vault" {
   run git diff-ansible-vault --vault-password-file .alternate-vault-pass --verbose
   assert_success


### PR DESCRIPTION
**Because:**
- Ansible Vault allows the vault password file to be set with a
  `ANSIBLE_VAULT_PASSWORD_FILE` environment variable.
  `git-diff-ansible-vault` should do the same, ref:
  http://docs.ansible.com/ansible/playbooks_vault.html#running-a-playbook-with-vault

**This change:**
- Use `ANSIBLE_VAULT_PASSWORD_FILE` environment variable for vault path
  if it's value exists as file.
- `--vault-password-file` takes precedence if set, same as it does for
  `ansible-vault`.

Fixes #9
