### PR TITLE
Setup man1 folder during make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PREFIX ?= /usr/local
 
 install: bin/git-diff-ansible-vault
 	@cp -p $< $(PREFIX)/$<
+	@mkdir -p $(PREFIX)/share/man/man1/
 	@cp -p man/git-diff-ansible-vault.1 $(PREFIX)/share/man/man1/
 
 uninstall:


### PR DESCRIPTION
## Because

The target directory `/usr/share/local/man/man1` does not always exist.

## This change

Adds the directory during `make install`.