### PR TITLE
Fix Ansible 2.9 incompatibility

### DIFF
--- a/bin/git-diff-ansible-vault
+++ b/bin/git-diff-ansible-vault
@@ -176,7 +176,7 @@ delete_tmp_vault_password_file() {
 #
 
 decrypted_vault_contents() {
-  ansible-vault --vault-password-file="$VAULT_PASSWORD_FILE" view <( echo "$1" )
+  ansible-vault view --vault-password-file="$VAULT_PASSWORD_FILE" <( echo "$1" )
   test $? -eq 0 || warn "Unable to open vault: $FILE_PATH"
 }
 

--- a/bin/git-diff-ansible-vault
+++ b/bin/git-diff-ansible-vault
@@ -105,7 +105,7 @@ ensure_dependencies() {
   command -v ansible-vault > /dev/null
   test $? -eq 0 || abort 'Unable to find ansible-vault'
 
-  ansible-vault --help 2> /dev/null | grep ^Usage | grep -qE '\[.*view.*\]'
+  ansible-vault --help 2> /dev/null | grep -qE '\bview\b'
   test $? -eq 0 || abort 'Unable to find `ansible-vault view`. Ansible 1.8 or later required.'
 }
 


### PR DESCRIPTION
This might affect previous 2.x releases as well. Two things changed:

1. `ansible-vault` will no longer accept the `--vault-password-file` argument before the command.
2. The output of `ansible-vault --help` no longer contains "Usage" followed by the list of commands. It looks like this:
```
usage: ansible-vault [-h] [--version] [-v]
                     {create,decrypt,edit,view,encrypt,encrypt_string,rekey}
                     ...

encryption/decryption utility for Ansible data files

positional arguments:
  {create,decrypt,edit,view,encrypt,encrypt_string,rekey}
    create              Create new vault encrypted file
    decrypt             Decrypt vault encrypted file
    edit                Edit vault encrypted file
    view                View vault encrypted file
    encrypt             Encrypt YAML file
    encrypt_string      Encrypt a string
    rekey               Re-key a vault encrypted file

optional arguments:
  --version             show program's version number, config file location,
                        configured module search path, module location,
                        executable location and exit
  -h, --help            show this help message and exit
  -v, --verbose         verbose mode (-vvv for more, -vvvv to enable
                        connection debugging)

See 'ansible-vault <command> --help' for more information on a specific
command.
```

I updated the usage of `ansible-vault` to place the `view` command before the other arguments.

I changed the dependency check to look for "view" in the help output, with word boundaries.

I believe both of these changes will support older versions of Ansible, but I did not test on every possible version to be sure.
